### PR TITLE
Fixed point_of_index for python3

### DIFF
--- a/scripts/functions.py
+++ b/scripts/functions.py
@@ -98,9 +98,9 @@ def index_of_point(mapData, Xp):
 
 def point_of_index(mapData, i):
     y = mapData.info.origin.position.y + \
-        (i/mapData.info.width)*mapData.info.resolution
+        (i//mapData.info.width)*mapData.info.resolution
     x = mapData.info.origin.position.x + \
-        (i-(i/mapData.info.width)*(mapData.info.width))*mapData.info.resolution
+        (i-(i//mapData.info.width)*(mapData.info.width))*mapData.info.resolution
     return array([x, y])
 # ________________________________________________________________________________
 


### PR DESCRIPTION
# What is this?

Since the integer division result is different between python2 and python3, I changed it so that the same result is output in python3.